### PR TITLE
fix Footnotes General Exception, because general note was removed.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -100,7 +100,7 @@ Another option is to allow multiple notes to be opened at the same time:
 
 Finally, you can control which notes you want to show. The default are:
 
-    f.notes = [:session, :cookies, :params, :filters, :routes, :env, :queries, :log, :general]
+    f.notes = [:session, :cookies, :params, :filters, :routes, :env, :queries, :log]
 
 Setting <tt>f.notes = []</tt> will show none of the available notes, although the supporting CSS and JavaScript will still be included. To completely disable all rails-footnotes content on a page, include <tt>params[:footnotes] = 'false'</tt> in the request.
 

--- a/lib/generators/templates/rails_footnotes.rb
+++ b/lib/generators/templates/rails_footnotes.rb
@@ -8,7 +8,7 @@ defined?(Footnotes) && Footnotes.setup do |f|
   # and should not be modified anywhere else.
 
   # Only toggle some notes :
-  # f.notes = [:session, :cookies, :params, :filters, :routes, :env, :queries, :log, :general]
+  # f.notes = [:session, :cookies, :params, :filters, :routes, :env, :queries, :log]
 
   # Change the prefix :
   # f.prefix = 'mvim://open?url=file://%s&line=%d&column=%d'


### PR DESCRIPTION
We can make initilizer for raise-footnotes from templates in lib/generators/templates/rails_footnotes.
But if we use it and start web server, we show below exception.

```
Footnotes General Exception: uninitialized constant Footnotes::Notes::GeneralNote
```

The `f.notes` setting in that template has `:general` note, but this note was removed at Footnotes v4.0.0.

