### PR TITLE
Can use view note on rails 3.2.x ~ 4.x 

### DIFF
--- a/lib/rails-footnotes/notes/view_note.rb
+++ b/lib/rails-footnotes/notes/view_note.rb
@@ -24,14 +24,10 @@ module Footnotes
       end
 
       def valid?
-        prefix? && first_render?
+        prefix? && filename && File.exists?(filename)
       end
 
       protected
-
-        def first_render?
-          @template.instance_variable_get(:@_first_render)
-        end
 
         def filename
           @filename ||= self.class.template[:file]

--- a/lib/rails-footnotes/notes/view_note.rb
+++ b/lib/rails-footnotes/notes/view_note.rb
@@ -34,7 +34,7 @@ module Footnotes
         end
 
         def filename
-          @filename ||= @template.instance_variable_get(:@_first_render).filename
+          @filename ||= self.class.template[:file]
         end
 
     end

--- a/lib/rails-footnotes/notes/view_note.rb
+++ b/lib/rails-footnotes/notes/view_note.rb
@@ -1,6 +1,15 @@
 module Footnotes
   module Notes
     class ViewNote < AbstractNote
+      cattr_accessor :template
+
+      def self.start!(controller)
+        @subscriber ||= ActiveSupport::Notifications.subscribe('render_template.action_view') do |*args|
+          event = ActiveSupport::Notifications::Event.new *args
+          self.template = {:file => event.payload[:identifier], :duration => event.duration}
+        end
+      end
+
       def initialize(controller)
         @controller = controller
         @template = controller.instance_variable_get(:@template)

--- a/lib/rails-footnotes/notes/view_note.rb
+++ b/lib/rails-footnotes/notes/view_note.rb
@@ -12,7 +12,6 @@ module Footnotes
 
       def initialize(controller)
         @controller = controller
-        @template = controller.instance_variable_get(:@template)
       end
 
       def row

--- a/lib/rails-footnotes/notes/view_note.rb
+++ b/lib/rails-footnotes/notes/view_note.rb
@@ -18,6 +18,10 @@ module Footnotes
         :edit
       end
 
+      def title
+        "View (#{"%.3f" % self.template[:duration]}ms)"
+      end
+
       def link
         escape(Footnotes::Filter.prefix(filename, 1, 1))
       end

--- a/spec/notes/view_note_spec.rb
+++ b/spec/notes/view_note_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+require "rails-footnotes/notes/view_note"
+
+describe Footnotes::Notes::ViewNote do
+
+  it "should not be valid if view file not exist" do
+    note = Footnotes::Notes::ViewNote.new(double)
+    note.stub(:filename).and_return(nil)
+
+    note.should_not be_valid
+  end
+end


### PR DESCRIPTION
View note doesn't work on rails 3.2.x ~ 4.x. 
Concretely, In Rails2 the current view is stored in the controller in an instance variable named @template. But It is different in rails 3.2.x and 4.x. So, I fix it with ActiveSupport::Notifications.

https://github.com/josevalim/rails-footnotes/pull/129/files#diff-4b7f440bebee87d9a63a043f54f49b1dL6

in addition, I added total time of view in view note.

![_1800__murakumo__1800_](https://cloud.githubusercontent.com/assets/2311539/7333907/ca4d5b1e-ebba-11e4-9602-512b04f0b14d.png)