### PR TITLE
Fix for using Log4r and Rails 3.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+  * Fix the issue of undefined method using Log4r and Rails 3.2
 == Footnotes v4.1.7 ==
   * Fix notes not collapsing when clicking on them again (#130)*
 == Footnotes v4.1.6 ==

--- a/lib/rails-footnotes/notes/log_note.rb
+++ b/lib/rails-footnotes/notes/log_note.rb
@@ -20,7 +20,7 @@ module Footnotes
           end
         # Rails 3 don't have ActiveSupport::Logger#broadcast so we backported it
         extend_module = defined?(ActiveSupport::Logger) ? ActiveSupport::Logger.broadcast(note_logger) : NoteLogger.broadcast(note_logger)
-        Rails.logger = self.original_logger.dup.extend(extend_module)
+        Rails.logger = self.original_logger.clone.extend(extend_module)
       end
 
       def title


### PR DESCRIPTION
Using Ruby 1.9.3-p484, Rails 3.2.22, Log4r 1.1.10, and Rails Footnotes 4.1.7.

I came across issues that had the following error messages: 
```
NoMethodError (private method `error' called for #<Log4r::Logger:0x000000143e19f8>):
```
```
NoMethodError: undefined method `info' for #<Log4r::Logger:0x000000143e19f8>
```

I tracked this issue down to Rails Footnotes trying to extend the logger. In [Rails 3.2, `dup`](http://apidock.com/rails/v3.2.13/ActiveRecord/Base/dup) initializes a new copy of the object and the Log4r configurations are not being set. `clone` makes an exact copy of the object.