### PR TITLE
Add back rails 3 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-edge
-    - gemfile: gemfiles/Gemfile.rails-3.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.1.6
   - 2.2.2
 gemfile:
-  - gemfiles/Gemfile.rails-3.2.x
+  - gemfiles/Gemfile.rails-3.2.22
   - gemfiles/Gemfile.rails-4.0.x
   - gemfiles/Gemfile.rails-4.1.x
   - gemfiles/Gemfile.rails-4.2.x
@@ -13,3 +13,4 @@ gemfile:
 matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-edge
+    - gemfile: gemfiles/Gemfile.rails-3.2.22

--- a/gemfiles/Gemfile.rails-3.2.22
+++ b/gemfiles/Gemfile.rails-3.2.22
@@ -2,5 +2,4 @@ source 'https://rubygems.org'
 
 gemspec :path => '..'
 
-gem 'rails', '~> 3.2.0'
-gem 'test-unit', '~> 3.0'
+gem 'rails', '~> 3.2.22'

--- a/gemfiles/Gemfile.rails-3.2.x
+++ b/gemfiles/Gemfile.rails-3.2.x
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec :path => '..'
 
 gem 'rails', '~> 3.2.0'
+gem 'test-unit', '~> 3.0'

--- a/lib/rails-footnotes/abstract_note.rb
+++ b/lib/rails-footnotes/abstract_note.rb
@@ -39,7 +39,7 @@ module Footnotes
         end
 
         # Action to be called after the Note was used.
-        # This is applied as an after_action.
+        # This is applied as an after_filter.
         #
         def close!(controller = nil)
         end

--- a/lib/rails-footnotes/extension.rb
+++ b/lib/rails-footnotes/extension.rb
@@ -6,17 +6,17 @@ module Footnotes
     extend ActiveSupport::Concern
 
     included do
-      prepend_before_action :rails_footnotes_before_action
-      after_action :rails_footnotes_after_action
+      prepend_before_filter :rails_footnotes_before_filter
+      after_filter :rails_footnotes_after_filter
     end
 
-    def rails_footnotes_before_action
+    def rails_footnotes_before_filter
       if Footnotes.enabled?(self)
         Footnotes::Filter.start!(self)
       end
     end
 
-    def rails_footnotes_after_action
+    def rails_footnotes_after_filter
       if Footnotes.enabled?(self)
         filter = Footnotes::Filter.new(self)
         filter.add_footnotes!


### PR DESCRIPTION
Rails 3.2.22 was released with support for Ruby 2.2. I can understand if you want to move away from 3.2 support, but at the moment, Ruby version shouldn't be the reason.

http://weblog.rubyonrails.org/2015/6/16/Rails-3-2-22-4-1-11-and-4-2-2-have-been-released-and-more/