### PR TITLE
Fixed: Dep Warning, Old Rails + unsupported ruby versions in .travis.yml, http in Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,10 @@ matrix:
   allow_failures:
     - gemfile: gemfiles/Gemfile.rails-edge
     - gemfile: gemfiles/Gemfile.rails-3.2.22
+  exclude:
+    - rvm: 1.9.3
+      gemfile: gemfiles/Gemfile.rails-edge
+    - rvm: 2.0.0
+      gemfile: gemfiles/Gemfile.rails-edge
+    - rvm: 2.1.7
+      gemfile: gemfiles/Gemfile.rails-edge

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
+cache: bundler
 sudo: false
 script: "bundle exec rake"
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.6
-  - 2.2.2
+  - 2.1.7
+  - 2.2.3
 gemfile:
   - gemfiles/Gemfile.rails-3.2.22
   - gemfiles/Gemfile.rails-4.0.x

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec

--- a/lib/rails-footnotes/extension.rb
+++ b/lib/rails-footnotes/extension.rb
@@ -6,8 +6,13 @@ module Footnotes
     extend ActiveSupport::Concern
 
     included do
-      prepend_before_filter :rails_footnotes_before_filter
-      after_filter :rails_footnotes_after_filter
+      if Rails::VERSION::MAJOR >= 5
+        prepend_before_action :rails_footnotes_before_filter
+        after_action :rails_footnotes_after_filter
+      else
+        prepend_before_filter :rails_footnotes_before_filter
+        after_filter :rails_footnotes_after_filter
+      end
     end
 
     def rails_footnotes_before_filter


### PR DESCRIPTION
Started over.

 * If Rails 5+, use **_action** instead of **_filter** to silent dep warning.
   * Changed "prepend_before_filter" to "prepend_before_action".
   * Changed "after_filter" to "after_action".

 * Updated .travis.yml to latest rails versions and excluded non-support ruby versions (< 2.2.1).

 * Changed http to https in Gemfile.

After merge, please merge with **rails** branch and I will check it out with my Rails 5 canary apps.

Thanks....
