### PR TITLE
fix `undefined method 'symbolize_keys'` error when use with Rails 5

### DIFF
--- a/lib/rails-footnotes/notes/params_note.rb
+++ b/lib/rails-footnotes/notes/params_note.rb
@@ -2,7 +2,11 @@ module Footnotes
   module Notes
     class ParamsNote < AbstractNote
       def initialize(controller)
-        @params = controller.params.symbolize_keys
+        @params = if Rails::VERSION::MAJOR >= 5
+          controller.params.to_unsafe_h
+        else
+          controller.params
+        end
       end
 
       def title


### PR DESCRIPTION
In https://github.com/rails/rails/commit/14a3bd520dd4bbf1247fd3e0071b59c02c115ce0,
ActionController::Parameters not inherited from Hash.

Therefore, since no longer be able to call directly `symbolize_keys`,
it has been modified to call is converted to the Hash.