### PR TITLE
Set SQL queries to correctly show milliseconds and not seconds

### DIFF
--- a/lib/rails-footnotes/notes/queries_note.rb
+++ b/lib/rails-footnotes/notes/queries_note.rb
@@ -47,7 +47,7 @@ module Footnotes
             <td>
               <span id="sql_#{index}">#{print_query(event.payload[:sql])}</span>
             </td>
-            <td>#{print_name_and_time(event.payload[:name], event.duration / 1000.0)}</td>
+            <td>#{print_name_and_time(event.payload[:name], event.duration)}</td>
           </tr>
           HTML
         end


### PR DESCRIPTION
Same as issue #74. Duration is already in milliseconds.

Incorrect:
![image](https://cloud.githubusercontent.com/assets/498234/12282562/eeecefae-b96c-11e5-8f5a-ad5a14b85f23.png)

Corrected:
![image](https://cloud.githubusercontent.com/assets/498234/12282578/118f5eb6-b96d-11e5-9d79-3798f01fdcda.png)
