### PR TITLE
improve readability for color-blind people - resolves https://github.com/josevalim/rails-footnotes/issues/146

### DIFF
--- a/lib/rails-footnotes/filter.rb
+++ b/lib/rails-footnotes/filter.rb
@@ -169,7 +169,7 @@ module Footnotes
           #footnotes_debug table td {padding: 5px; border-bottom: 1px solid #ccc;}
           #footnotes_debug table td strong {color: #9b1b1b;}
           #footnotes_debug table th {padding: 5px; border-bottom: 1px solid #ccc;}
-          #footnotes_debug table tr:nth-child(2n) td {background: #eee;}
+          #footnotes_debug table tr:nth-child(2n) td {background: #f5f5f5;}
           #footnotes_debug table tr:nth-child(2n + 1) td {background: #fff;}
           #footnotes_debug tbody {text-align: left;}
           #footnotes_debug .name_values td {vertical-align: top;}

--- a/lib/rails-footnotes/notes/queries_note.rb
+++ b/lib/rails-footnotes/notes/queries_note.rb
@@ -23,8 +23,8 @@ module Footnotes
       def title
         queries = self.events.count
         total_time = self.events.map(&:duration).sum
-        query_color = generate_red_color(self.events.count, alert_sql_number)
-        db_color    = generate_red_color(total_time, alert_db_time)
+        query_color = alert_color(self.events.count, alert_sql_number)
+        db_color    = alert_color(total_time, alert_db_time)
 
         <<-TITLE
         <span style="background-color:#{query_color}">Queries (#{queries})</span>
@@ -57,17 +57,16 @@ module Footnotes
 
       protected
       def print_name_and_time(name, time)
-        "<span style='background-color:#{generate_red_color(time, alert_ratio)}'>#{escape(name || 'SQL')} (#{'%.3fms' % time})</span>"
+        "<span style='background-color:#{alert_color(time, alert_ratio)}'>#{escape(name || 'SQL')} (#{'%.3fms' % time})</span>"
       end
 
       def print_query(query)
         escape(query.to_s.gsub(/(\s)+/, ' ').gsub('`', ''))
       end
 
-      def generate_red_color(value, alert)
-        c = ((value.to_f/alert).to_i - 1) * 16
-        c = 0  if c < 0; c = 15 if c > 15; c = (15-c).to_s(16)
-        "#ff#{c*4}"
+      def alert_color(value, threshold)
+        return 'transparent' if value < threshold
+        '#ffff00'
       end
 
       def alert_ratio
@@ -103,7 +102,7 @@ module Footnotes
       attr_accessor :events, :ignore_regexps
 
       def initialize(orm)
-        super() 
+        super()
         @events = []
         orm.each {|adapter| ActiveSupport::LogSubscriber.attach_to adapter, self}
       end


### PR DESCRIPTION
Use yellow to highlight areas needing attention, rather than red.

The red was generated by the `generate_red_color` method, which basically output `#ffffff` if the `value` was less than **double** the `alert` level, and `#ff0000` if the `value` was more than double the `alert` level. Based on the method name and how convoluted the code was, I suspect `generate_red_color` may have been intended to produce darker levels of red depending on how far over the `alert` value you were. In any case, it didn't work that way.

I've simplified it: it just gives yellow if you're over the `threshold` amount, and transparent otherwise.

I've also slightly lightened the 'alternate' table row color to improve contrast/readability there.

![screen shot 2016-01-27 at 10 08 27 am](https://cloud.githubusercontent.com/assets/145042/12598371/01f2386c-c4de-11e5-9620-2c8428c0fbd0.png)
