### PR TITLE
Fix errors when running Rails without Sprockets

### DIFF
--- a/lib/rails-footnotes/notes/files_note.rb
+++ b/lib/rails-footnotes/notes/files_note.rb
@@ -28,7 +28,7 @@ module Footnotes
         end
 
         def parse_files!
-          asset_paths = Rails.application.config.assets.paths
+          asset_paths = Rails.application.config.try(:assets).try(:paths) || []
           linked_files = []
 
           @files.collect do |file|


### PR DESCRIPTION
When creating Rails app with `--skip-sprockets`, `Rails::Application::Configuration` does not know `assets` method so that the following error occurs because now it is the method which is added by Sprockets and Rails itself no longer has it on `Rails::Application::Configuration` (like I have reported in [this issue](#149)).

I don't know how common that Rails app is configured without Sprockets, but I have added a check if `Rails.application.config` responds to `assets`.